### PR TITLE
STYLE: Use Macro for Function Deletion

### DIFF
--- a/include/itkBinaryCloseParaImageFilter.h
+++ b/include/itkBinaryCloseParaImageFilter.h
@@ -157,8 +157,7 @@ protected:
   typedef typename itk::GreaterEqualValImageFilter< InternalIntImageType, OutputImageType >  RCastTypeA;
   typedef typename itk::BinaryThresholdImageFilter< InternalRealImageType, OutputImageType > RCastTypeB;
 private:
-  BinaryCloseParaImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);             //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryCloseParaImageFilter);
 
   RadiusType m_Radius;
   bool       m_Circular;

--- a/include/itkBinaryDilateParaImageFilter.h
+++ b/include/itkBinaryDilateParaImageFilter.h
@@ -142,8 +142,7 @@ protected:
   typedef typename itk::BinaryThresholdImageFilter< InternalRealImageType, OutputImageType > CCastType;
   typedef typename itk::BinaryThresholdImageFilter< InternalRealImageType, OutputImageType > RCastType;
 private:
-  BinaryDilateParaImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);              //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryDilateParaImageFilter);
 
   RadiusType m_Radius;
   bool       m_Circular;

--- a/include/itkBinaryErodeParaImageFilter.h
+++ b/include/itkBinaryErodeParaImageFilter.h
@@ -143,8 +143,7 @@ protected:
   typedef typename itk::GreaterEqualValImageFilter< InternalRealImageType, OutputImageType > CCastType;
   typedef typename itk::GreaterEqualValImageFilter< InternalIntImageType, OutputImageType >  RCastType;
 private:
-  BinaryErodeParaImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);             //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryErodeParaImageFilter);
 
   RadiusType m_Radius;
   bool       m_Circular;

--- a/include/itkBinaryOpenParaImageFilter.h
+++ b/include/itkBinaryOpenParaImageFilter.h
@@ -157,8 +157,7 @@ protected:
   typedef typename itk::GreaterEqualValImageFilter< InternalIntImageType, OutputImageType >  RCastTypeA;
   typedef typename itk::BinaryThresholdImageFilter< InternalRealImageType, OutputImageType > RCastTypeB;
 private:
-  BinaryOpenParaImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);            //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryOpenParaImageFilter);
 
   RadiusType m_Radius;
   bool       m_Circular;

--- a/include/itkGreaterEqualValImageFilter.h
+++ b/include/itkGreaterEqualValImageFilter.h
@@ -99,8 +99,7 @@ protected:
   GreaterEqualValImageFilter() {}
   virtual ~GreaterEqualValImageFilter() {}
 private:
-  GreaterEqualValImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);             //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(GreaterEqualValImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkMorphSDTHelperImageFilter.h
+++ b/include/itkMorphSDTHelperImageFilter.h
@@ -126,8 +126,7 @@ protected:
   MorphSDTHelperImageFilter() {}
   virtual ~MorphSDTHelperImageFilter() {}
 private:
-  MorphSDTHelperImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);            //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(MorphSDTHelperImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkMorphologicalDistanceTransformImageFilter.h
+++ b/include/itkMorphologicalDistanceTransformImageFilter.h
@@ -142,10 +142,7 @@ protected:
   typedef typename itk::ParabolicErodeImageFilter< OutputImageType, OutputImageType > ErodeType;
   typedef typename itk::SqrtImageFilter< OutputImageType, OutputImageType >           SqrtType;
 private:
-  MorphologicalDistanceTransformImageFilter(const Self &); //purposely not
-                                                           // implemented
-  void operator=(const Self &);                            //purposely not
-                                                           // implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalDistanceTransformImageFilter);
 
   InputPixelType               m_OutsideValue;
   typename ErodeType::Pointer  m_Erode;

--- a/include/itkMorphologicalSharpeningImageFilter.h
+++ b/include/itkMorphologicalSharpeningImageFilter.h
@@ -163,8 +163,7 @@ protected:
   typedef typename itk::SharpenOpImageFilter< OutputImageType, OutputImageType, OutputImageType,
                                               OutputImageType > SharpenOpType;
 private:
-  MorphologicalSharpeningImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);                     //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalSharpeningImageFilter);
 
   int m_Iterations;
 

--- a/include/itkMorphologicalSignedDistanceTransformImageFilter.h
+++ b/include/itkMorphologicalSignedDistanceTransformImageFilter.h
@@ -187,10 +187,7 @@ protected:
   typedef typename itk::ParabolicDilateImageFilter< OutputImageType, OutputImageType > DilateType;
   typedef typename itk::MorphSDTHelperImageFilter< OutputImageType, OutputImageType >  HelperType;
 private:
-  MorphologicalSignedDistanceTransformImageFilter(const Self &); //purposely not
-                                                                 // implemented
-  void operator=(const Self &);                                  //purposely not
-                                                                 // implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalSignedDistanceTransformImageFilter);
 
   InputPixelType               m_OutsideValue;
   bool                         m_InsideIsPositive;

--- a/include/itkParabolicCloseImageFilter.h
+++ b/include/itkParabolicCloseImageFilter.h
@@ -91,8 +91,7 @@ protected:
   virtual ~ParabolicCloseImageFilter() {}
 //   void PrintSelf(std::ostream& os, Indent indent) const;
 private:
-  ParabolicCloseImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);            //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicCloseImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkParabolicDilateImageFilter.h
+++ b/include/itkParabolicDilateImageFilter.h
@@ -86,8 +86,7 @@ protected:
   virtual ~ParabolicDilateImageFilter() {}
 //   void PrintSelf(std::ostream& os, Indent indent) const;
 private:
-  ParabolicDilateImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);             //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicDilateImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkParabolicErodeDilateImageFilter.h
+++ b/include/itkParabolicErodeDilateImageFilter.h
@@ -195,8 +195,7 @@ protected:
   bool m_UseImageSpacing;
   int  m_ParabolicAlgorithm;
 private:
-  ParabolicErodeDilateImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);                  //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicErodeDilateImageFilter);
 
   RadiusType m_Scale;
 

--- a/include/itkParabolicErodeImageFilter.h
+++ b/include/itkParabolicErodeImageFilter.h
@@ -90,8 +90,7 @@ protected:
   virtual ~ParabolicErodeImageFilter() {}
 //   void PrintSelf(std::ostream& os, Indent indent) const;
 private:
-  ParabolicErodeImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);            //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicErodeImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkParabolicOpenCloseImageFilter.h
+++ b/include/itkParabolicOpenCloseImageFilter.h
@@ -162,8 +162,7 @@ protected:
 
   int m_ParabolicAlgorithm;
 private:
-  ParabolicOpenCloseImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);                //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenCloseImageFilter);
 
   RadiusType m_Scale;
 

--- a/include/itkParabolicOpenCloseSafeBorderImageFilter.h
+++ b/include/itkParabolicOpenCloseSafeBorderImageFilter.h
@@ -161,10 +161,7 @@ protected:
   virtual ~ParabolicOpenCloseSafeBorderImageFilter() {}
   int m_ParabolicAlgorithm;
 private:
-  ParabolicOpenCloseSafeBorderImageFilter(const Self &); //purposely not
-                                                         // implemented
-  void operator=(const Self &);                          //purposely not
-                                                         // implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenCloseSafeBorderImageFilter);
 
   typename MorphFilterType::Pointer m_MorphFilt;
   typename PadFilterType::Pointer   m_PadFilt;

--- a/include/itkParabolicOpenImageFilter.h
+++ b/include/itkParabolicOpenImageFilter.h
@@ -87,8 +87,7 @@ protected:
   virtual ~ParabolicOpenImageFilter() {}
 //   void PrintSelf(std::ostream& os, Indent indent) const;
 private:
-  ParabolicOpenImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);           //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkSharpenOpImageFilter.h
+++ b/include/itkSharpenOpImageFilter.h
@@ -110,8 +110,7 @@ protected:
   SharpenOpImageFilter() {}
   virtual ~SharpenOpImageFilter() {}
 private:
-  SharpenOpImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);       //purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(SharpenOpImageFilter);
 };
 } // end namespace itk
 


### PR DESCRIPTION
@hjmjohnson
Use ITK_DISALLOW_COPY_AND_ASSIGN macro to delete copy and assignment constructors which uses c++11's rigorous function deletion on compilers that support it.