### PR TITLE
COMP: Remove override warnings

### DIFF
--- a/include/itkBinaryCloseParaImageFilter.h
+++ b/include/itkBinaryCloseParaImageFilter.h
@@ -138,11 +138,11 @@ public:
 
   /* add in the traits here */
 protected:
-  void GenerateData(void);
+  void GenerateData(void) ITK_OVERRIDE;
 
   BinaryCloseParaImageFilter();
   virtual ~BinaryCloseParaImageFilter() {}
-  void PrintSelf(std::ostream & os, Indent indent) const;
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
   typedef typename itk::Image< InternalRealType, InputImageType::ImageDimension >            InternalRealImageType;
   typedef typename itk::Image< InternalIntType, InputImageType::ImageDimension >             InternalIntImageType;

--- a/include/itkBinaryDilateParaImageFilter.h
+++ b/include/itkBinaryDilateParaImageFilter.h
@@ -110,7 +110,7 @@ public:
   itkSetMacro(Radius, RadiusType);
   itkGetConstReferenceMacro(Radius, RadiusType);
 
-  virtual void Modified() const;
+  virtual void Modified() const ITK_OVERRIDE;
 
   void SetUseImageSpacing(bool g)
   {
@@ -129,11 +129,11 @@ public:
 
   /* add in the traits here */
 protected:
-  void GenerateData(void);
+  void GenerateData(void) ITK_OVERRIDE;
 
   BinaryDilateParaImageFilter();
   virtual ~BinaryDilateParaImageFilter() {}
-  void PrintSelf(std::ostream & os, Indent indent) const;
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
   typedef typename itk::Image< InternalRealType, InputImageType::ImageDimension >            InternalRealImageType;
   typedef typename itk::Image< InternalIntType, InputImageType::ImageDimension >             InternalIntImageType;

--- a/include/itkBinaryErodeParaImageFilter.h
+++ b/include/itkBinaryErodeParaImageFilter.h
@@ -127,14 +127,14 @@ public:
   /** Image related typedefs. */
 
   /* add in the traits here */
-  virtual void Modified() const;
+  virtual void Modified() const ITK_OVERRIDE;
 
 protected:
-  void GenerateData(void);
+  void GenerateData(void) ITK_OVERRIDE;
 
   BinaryErodeParaImageFilter();
   virtual ~BinaryErodeParaImageFilter() {}
-  void PrintSelf(std::ostream & os, Indent indent) const;
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
   typedef typename itk::Image< InternalRealType, InputImageType::ImageDimension >            InternalRealImageType;
   typedef typename itk::Image< InternalIntType, InputImageType::ImageDimension >             InternalIntImageType;

--- a/include/itkBinaryOpenParaImageFilter.h
+++ b/include/itkBinaryOpenParaImageFilter.h
@@ -138,11 +138,11 @@ public:
 
   /* add in the traits here */
 protected:
-  void GenerateData(void);
+  void GenerateData(void) ITK_OVERRIDE;
 
   BinaryOpenParaImageFilter();
   virtual ~BinaryOpenParaImageFilter() {}
-  void PrintSelf(std::ostream & os, Indent indent) const;
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
   typedef typename itk::Image< InternalRealType, InputImageType::ImageDimension >            InternalRealImageType;
   typedef typename itk::Image< InternalIntType, InputImageType::ImageDimension >             InternalIntImageType;

--- a/include/itkMorphologicalDistanceTransformImageFilter.h
+++ b/include/itkMorphologicalDistanceTransformImageFilter.h
@@ -95,7 +95,7 @@ public:
 
   /** a type to represent the "kernel radius" */
   typedef typename itk::FixedArray< ScalarRealType, TInputImage::ImageDimension > RadiusType;
-  virtual void Modified() const;
+  virtual void Modified() const ITK_OVERRIDE;
 
   /** this describes the input mask - default value 0 - we compute the
   distance from all voxels with value not equal to "OutsideValue" to
@@ -132,10 +132,10 @@ public:
 protected:
   MorphologicalDistanceTransformImageFilter();
   virtual ~MorphologicalDistanceTransformImageFilter() {}
-  void PrintSelf(std::ostream & os, Indent indent) const;
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
   /** Generate Data */
-  void GenerateData(void);
+  void GenerateData(void) ITK_OVERRIDE;
 
   // do everything in the output image type, which should have high precision
   typedef typename itk::BinaryThresholdImageFilter< InputImageType, OutputImageType > ThreshType;

--- a/include/itkMorphologicalSharpeningImageFilter.h
+++ b/include/itkMorphologicalSharpeningImageFilter.h
@@ -150,10 +150,10 @@ public:
 protected:
   MorphologicalSharpeningImageFilter();
   virtual ~MorphologicalSharpeningImageFilter() {}
-  void PrintSelf(std::ostream & os, Indent indent) const;
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
   /** Generate Data */
-  void GenerateData(void);
+  void GenerateData(void) ITK_OVERRIDE;
 
   // do everything in the output image type, which should have high precision
   typedef typename itk::ParabolicErodeImageFilter< OutputImageType, OutputImageType >  ErodeType;

--- a/include/itkParabolicErodeDilateImageFilter.h
+++ b/include/itkParabolicErodeDilateImageFilter.h
@@ -177,20 +177,20 @@ public:
 protected:
   ParabolicErodeDilateImageFilter();
   virtual ~ParabolicErodeDilateImageFilter() {}
-  void PrintSelf(std::ostream & os, Indent indent) const;
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
   /** Generate Data */
-  void GenerateData(void);
+  void GenerateData(void) ITK_OVERRIDE;
 
   unsigned int SplitRequestedRegion(unsigned int i, unsigned int num,
-                                    OutputImageRegionType & splitRegion);
+                                    OutputImageRegionType & splitRegion) ITK_OVERRIDE;
 
-  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId);
+  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) ITK_OVERRIDE;
 
-  void GenerateInputRequestedRegion() throw( InvalidRequestedRegionError );
+  void GenerateInputRequestedRegion() throw( InvalidRequestedRegionError ) ITK_OVERRIDE;
 
   // Override since the filter produces the entire dataset.
-  void EnlargeOutputRequestedRegion(DataObject *output);
+  void EnlargeOutputRequestedRegion(DataObject *output) ITK_OVERRIDE;
 
   bool m_UseImageSpacing;
   int  m_ParabolicAlgorithm;

--- a/include/itkParabolicOpenCloseImageFilter.h
+++ b/include/itkParabolicOpenCloseImageFilter.h
@@ -145,20 +145,20 @@ public:
 protected:
   ParabolicOpenCloseImageFilter();
   virtual ~ParabolicOpenCloseImageFilter() {}
-  void PrintSelf(std::ostream & os, Indent indent) const;
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
   /** Generate Data */
-  void GenerateData(void);
+  void GenerateData(void) ITK_OVERRIDE;
 
   unsigned int SplitRequestedRegion(unsigned int i, unsigned int num,
-                                    OutputImageRegionType & splitRegion);
+                                    OutputImageRegionType & splitRegion) ITK_OVERRIDE;
 
-  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId);
+  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) ITK_OVERRIDE;
 
-  virtual void GenerateInputRequestedRegion() throw( InvalidRequestedRegionError );
+  virtual void GenerateInputRequestedRegion() throw( InvalidRequestedRegionError ) ITK_OVERRIDE;
 
   // Override since the filter produces the entire dataset.
-  void EnlargeOutputRequestedRegion(DataObject *output);
+  void EnlargeOutputRequestedRegion(DataObject *output) ITK_OVERRIDE;
 
   int m_ParabolicAlgorithm;
 private:

--- a/include/itkParabolicOpenCloseSafeBorderImageFilter.h
+++ b/include/itkParabolicOpenCloseSafeBorderImageFilter.h
@@ -136,12 +136,12 @@ public:
 
   /** ParabolicOpenCloseImageFilter must forward the Modified() call to its
     internal filters */
-  virtual void Modified() const;
+  virtual void Modified() const ITK_OVERRIDE;
 
 protected:
-  void GenerateData();
+  void GenerateData() ITK_OVERRIDE;
 
-  void PrintSelf(std::ostream & os, Indent indent) const;
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
   typedef ParabolicOpenCloseImageFilter< TInputImage, doOpen, TOutputImage > MorphFilterType;
   typedef ConstantPadImageFilter< TInputImage, TInputImage >                 PadFilterType;


### PR DESCRIPTION
Overrides a member function but is not
marked 'override' [-Winconsistent-missing-override]