### PR TITLE
change spacing back to original

### DIFF
--- a/test/itkParaSpacingTest.cxx
+++ b/test/itkParaSpacingTest.cxx
@@ -90,8 +90,9 @@ int itkParaSpacingTest(int, char *argv[])
   typedef itk::ChangeInformationImageFilter< IType > ChangeType;
   ChangeType::Pointer changer = ChangeType::New();
   changer->SetInput( reader->GetOutput() );
-  ChangeType::SpacingType newspacing;
+  ChangeType::SpacingType oldspacing, newspacing;
 
+  oldspacing = filter->GetOutput()->GetSpacing();
   newspacing[0] = 1 / sqrt( (float)1 );
   newspacing[1] = 1 / sqrt( (float)0.5 );
 
@@ -103,15 +104,22 @@ int itkParaSpacingTest(int, char *argv[])
   filter->SetInput( changer->GetOutput() );
   filter->SetScale(scale);
   filter->SetUseImageSpacing(true);
+  // change the spacing back to original to allow comparison
+  ChangeType::Pointer changerback = ChangeType::New();
+  changerback->SetInput( filter->GetOutput() );
+  changerback->SetOutputSpacing(oldspacing);
+  changerback->ChangeSpacingOn();
+
   try
     {
-    filter->Update();
+    changerback->Update();
     }
   catch ( itk::ExceptionObject & excp )
     {
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;
     }
+  writer->SetInput(changerback->GetOutput());
   writer->SetFileName(argv[3]);
   try
     {


### PR DESCRIPTION
The spacing test manipulates image spacing to give the same result as achieved by setting parabola scales. The original version didn't change the spacing back in order to compare results, which is a problem now that the png writer is able to record spacing information. This fix changes the spacing back to the original value prior to writing output.